### PR TITLE
chore: run migrations on start

### DIFF
--- a/src/database/utils/runMigrations.ts
+++ b/src/database/utils/runMigrations.ts
@@ -1,42 +1,12 @@
-import * as path from 'path'
-import { promises as fs } from 'fs'
-import { Migrator, FileMigrationProvider } from 'kysely'
 import { config } from 'dotenv'
-import { generateDb } from './pg.utils'
+import { executeMigration, generateDb } from './pg.utils'
 
 config()
 
 const migrateToLatest = async () => {
   const { db } = generateDb()
 
-  const migrator = new Migrator({
-    db,
-    provider: new FileMigrationProvider({
-      fs,
-      path,
-      migrationFolder: path.join(__dirname, '../migrations'),
-    }),
-  })
-
-  const { error, results } = await migrator.migrateToLatest()
-
-  results?.forEach((migrationResult) => {
-    if (migrationResult.status === 'Success') {
-      console.log(
-        `Migration "${migrationResult.migrationName}" was executed successfully`,
-      )
-    } else if (migrationResult.status === 'Error') {
-      console.error(
-        `Failed to execute migration "${migrationResult.migrationName}"`,
-      )
-    }
-  })
-
-  if (error) {
-    console.error('Failed to migrate')
-    console.error(error)
-    process.exit(1)
-  }
+  await executeMigration(db)
 
   await db.destroy()
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { AppModule } from './app.module'
 import { ConfigService } from '@nestjs/config'
 import { DatabaseService } from './database/database.service'
 import { session } from 'telegraf'
+import { executeMigration } from './database/utils/pg.utils'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
@@ -22,6 +23,7 @@ async function bootstrap() {
       getSessionKey: (ctx) => `${ctx.from.id}`,
     }),
   )
+  await executeMigration(databaseService.bouncerStore)
   app.use(bot.webhookCallback(configService.get<string>('bot.path')))
   await app.listen(3000)
 }


### PR DESCRIPTION
Modifies startup to automatically run migrations, when possible. The ability to run migrations separately via script is still available - this serves as an easier way to get the bouncer up and running out of the box.