### PR TITLE
chore: move migration to build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "nest build",
+    "build": "ts-node ./src/database/utils/runMigrations.ts && nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,6 @@ async function bootstrap() {
       getSessionKey: (ctx) => `${ctx.from.id}`,
     }),
   )
-  await executeMigration(databaseService.bouncerStore)
   app.use(bot.webhookCallback(configService.get<string>('bot.path')))
   await app.listen(3000)
 }


### PR DESCRIPTION
Moves the db migration to build step, to prevent 403 errors on vercel.