### PR TITLE
build(vercel): rejig to accommodate build norms

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { vercelHandler } = require('../dist/app')
+
+module.exports = vercelHandler

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,41 @@
+import 'dotenv/config'
+import { NestFactory } from '@nestjs/core'
+import { getBotToken } from 'nestjs-telegraf'
+import cookieParser from 'cookie-parser'
+
+import { AppModule } from './app.module'
+import { ConfigService } from '@nestjs/config'
+import { DatabaseService } from './database/database.service'
+import { session } from 'telegraf'
+import { IncomingMessage, ServerResponse } from 'http'
+
+export async function init() {
+  const app = await NestFactory.create(AppModule)
+  const configService = app.get<ConfigService>(ConfigService)
+  const databaseService = app.get<DatabaseService>(DatabaseService)
+
+  app.use(cookieParser())
+
+  const bot = app.get(getBotToken())
+  bot.use(
+    session({
+      store: databaseService.store,
+      getSessionKey: (ctx) => `${ctx.from.id}`,
+    }),
+  )
+  app.use(bot.webhookCallback(configService.get<string>('bot.path')))
+  return app
+}
+
+export const appPromise = init().then(async (app) => {
+  await app.init()
+  return app
+})
+
+export const vercelHandler = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => {
+  const app = await appPromise
+  app.getHttpAdapter().getInstance()(req, res)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,29 +1,7 @@
-import 'dotenv/config'
-import { NestFactory } from '@nestjs/core'
-import { getBotToken } from 'nestjs-telegraf'
-import cookieParser from 'cookie-parser'
-
-import { AppModule } from './app.module'
-import { ConfigService } from '@nestjs/config'
-import { DatabaseService } from './database/database.service'
-import { session } from 'telegraf'
-import { executeMigration } from './database/utils/pg.utils'
+import { appPromise } from './app'
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule)
-  const configService = app.get<ConfigService>(ConfigService)
-  const databaseService = app.get<DatabaseService>(DatabaseService)
-
-  app.use(cookieParser())
-
-  const bot = app.get(getBotToken())
-  bot.use(
-    session({
-      store: databaseService.store,
-      getSessionKey: (ctx) => `${ctx.from.id}`,
-    }),
-  )
-  app.use(bot.webhookCallback(configService.get<string>('bot.path')))
-  await app.listen(3000)
+  const app = await appPromise
+  app.listen(3000)
 }
 bootstrap()

--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,4 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "src/main.ts",
-      "use": "@vercel/node"
-    }
-  ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "src/main.ts",
-      "methods": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-    }
-  ]
+  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
 }


### PR DESCRIPTION
## Problem
telegovsg was reliant on Vercel's legacy build features which interfere with build steps that we wanted to do, eg, performing migrations via `npm run build`. Further, the set up was reliant on the legacy `@vercel/node` runtime, which would remap port listening to the handler, but obscures what really is happening.

## Solution
- Shard `app` from `main`, to allow others to obtain a Nest instance
  - Also add export of response handler wrapper for vercel
- Add `api/index.js` shim for vercel, `public/robots.txt` to trick vercel
- Rewrite Vercel config to make use of shim
